### PR TITLE
Ur initializer and sub-urs' parent #ur

### DIFF
--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -43,6 +43,7 @@ Ur = JSI.class_for_schema({
 class Ur
   VERSION = UR_VERSION
 
+  autoload :SubUr, 'ur/sub_ur'
   autoload :RequestAndResponse, 'ur/request_and_response'
   autoload :Middleware, 'ur/middleware'
   autoload :FaradayMiddleware, 'ur/middleware'

--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -106,8 +106,8 @@ class Ur
     end
   end
 
-  def initialize(ur = {}, *a, &b)
-    super(ur, *a, &b)
+  def initialize(ur = {}, **opt, &b)
+    super(ur, **opt, &b)
     unless instance.respond_to?(:to_hash)
       raise(TypeError, "expected hash argument. got: #{ur.pretty_inspect.chomp}")
     end

--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -107,6 +107,7 @@ class Ur
   end
 
   def initialize(ur = {}, **opt, &b)
+    ur = JSI::JSON::Node.new_doc(ur) unless ur.is_a?(JSI::JSON::Node)
     super(ur, **opt, &b)
     unless instance.respond_to?(:to_hash)
       raise(TypeError, "expected hash argument. got: #{ur.pretty_inspect.chomp}")

--- a/lib/ur/processing.rb
+++ b/lib/ur/processing.rb
@@ -2,6 +2,8 @@ require 'ur' unless Object.const_defined?(:Ur)
 
 class Ur
   class Processing
+    include SubUr
+
     def began_at
       began_at_s ? Time.parse(began_at_s) : nil
     end

--- a/lib/ur/request.rb
+++ b/lib/ur/request.rb
@@ -3,6 +3,7 @@ require 'ur' unless Object.const_defined?(:Ur)
 class Ur
   class Request
     include RequestAndResponse
+    include SubUr
 
     def addressable_uri
       uri ? Addressable::URI.parse(uri) : nil

--- a/lib/ur/sub_ur.rb
+++ b/lib/ur/sub_ur.rb
@@ -2,5 +2,8 @@ require 'ur' unless Object.const_defined?(:Ur)
 
 class Ur
   module SubUr
+    def ur
+      parents.detect { |p| p.is_a?(::Ur) }
+    end
   end
 end

--- a/lib/ur/sub_ur.rb
+++ b/lib/ur/sub_ur.rb
@@ -1,8 +1,6 @@
 require 'ur' unless Object.const_defined?(:Ur)
 
 class Ur
-  class Response
-    include RequestAndResponse
-    include SubUr
+  module SubUr
   end
 end


### PR DESCRIPTION
- Ur#initialize matches JSI::Base#initialize better
- Ur#initialize ensures its instance is a JSI::JSON::Node so its children (#request, #response, #processing, whatever else may be added or exist) know how to find their parent ur
- Ur children, now called SubUr (as a module) have a parent #ur 