### PR TITLE
Ur#origin

### DIFF
--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -69,7 +69,7 @@ class Ur
         env = request_env
       end
 
-      new({'bound' => 'inbound'}).tap do |ur|
+      new({'bound' => 'inbound'}, origin: request_env).tap do |ur|
         ur.processing.begin!
 
         ur.request['method'] = rack_request.request_method
@@ -102,7 +102,7 @@ class Ur
     end
 
     def from_faraday_request(request_env, logger: nil)
-      new({'bound' => 'outbound'}).tap do |ur|
+      new({'bound' => 'outbound'}, origin: request_env).tap do |ur|
         ur.processing.begin!
         ur.request['method'] = request_env[:method].to_s
         ur.request.uri = request_env[:url].normalize.to_s

--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -112,15 +112,17 @@ class Ur
     end
   end
 
-  def initialize(ur = {}, **opt, &b)
+  def initialize(ur = {}, origin: nil, **opt, &b)
     super(ur, **opt, &b)
     unless instance.respond_to?(:to_hash)
       raise(TypeError, "expected hash argument. got: #{ur.pretty_inspect.chomp}")
     end
+    @origin = origin
     self.request = {} if self.request.nil?
     self.response = {} if self.response.nil?
     self.processing = {} if self.processing.nil?
   end
+  attr_reader :origin
 
   def logger=(logger)
     if logger && logger.formatter.respond_to?(:current_tags)


### PR DESCRIPTION
Ur stores its origin. this will be an arbitrary object such as a Rack::Request, a plain rack env hash, a Faraday::Response, an HTTPI object of some sort - whatever its original representation was.

needs doc.