### PR TITLE
Misc

### DIFF
--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -147,4 +147,18 @@ class Ur
       yield(response_env)
     end
   end
+
+  # define delegator sort of methods for nested property names, eg.
+  #    ur.request_uri
+  # this makes it easier to use Symbol#to_proc, eg urs.map(&:request_uri)
+  # instead of urs.map(&:request).map(&:uri)
+  schema['properties'].each do |property_name, property_schema|
+    if property_schema['type'] == 'object' && property_schema['properties']
+      property_schema['properties'].each_key do |property_property_name|
+        define_method("#{property_name}_#{property_property_name}") do
+          self[property_name][property_property_name]
+        end
+      end
+    end
+  end
 end

--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -65,7 +65,7 @@ class Ur
         env = request_env
       end
 
-      Ur.new({}).tap do |ur|
+      new({}).tap do |ur|
         ur.processing.begin!
         ur.bound = 'inbound'
         ur.request['method'] = rack_request.request_method
@@ -95,7 +95,7 @@ class Ur
     end
 
     def from_faraday_request(request_env, logger: nil)
-      Ur.new({}).tap do |ur|
+      new({}).tap do |ur|
         ur.processing.begin!
         ur.bound = 'outbound'
         ur.request['method'] = request_env[:method].to_s

--- a/lib/ur.rb
+++ b/lib/ur.rb
@@ -65,9 +65,8 @@ class Ur
         env = request_env
       end
 
-      new({}).tap do |ur|
+      new({'bound' => 'inbound'}).tap do |ur|
         ur.processing.begin!
-        ur.bound = 'inbound'
         ur.request['method'] = rack_request.request_method
         ur.request.headers = env.map do |(key, value)|
           http_match = key.match(/\AHTTP_/)
@@ -95,9 +94,8 @@ class Ur
     end
 
     def from_faraday_request(request_env, logger: nil)
-      new({}).tap do |ur|
+      new({'bound' => 'outbound'}).tap do |ur|
         ur.processing.begin!
-        ur.bound = 'outbound'
         ur.request['method'] = request_env[:method].to_s
         ur.request.headers = request_env[:request_headers]
         ur.request.uri = request_env[:url].normalize.to_s

--- a/lib/ur/response.rb
+++ b/lib/ur/response.rb
@@ -3,5 +3,17 @@ require 'ur' unless Object.const_defined?(:Ur)
 class Ur
   class Response
     include RequestAndResponse
+
+    def success?
+      (200..299).include?(status)
+    end
+
+    def client_error?
+      (400..499).include?(status)
+    end
+
+    def server_error?
+      (500..599).include?(status)
+    end
   end
 end


### PR DESCRIPTION
- fix for instantiating subclasses of Ur from rack or faraday
- delegator methods to sub-properties e.g. ur.request_uri instead of ur.request.uri
- Ur::Response#success?, #client_error?, #server_error?
- minor refactor to put 'bound' as the first key in the ur
